### PR TITLE
Sort sheets response by given order

### DIFF
--- a/src/Builder/Sheets.builder.ts
+++ b/src/Builder/Sheets.builder.ts
@@ -57,6 +57,17 @@ export class SheetsBuilder implements JsonBuilder {
   }
 
   toJSON(): ContestResponse[] {
-    return Object.values(this._contestsIndexer);
+    return this._sortContests(Object.values(this._contestsIndexer));
+  }
+
+  private _sortContests(contests: ContestResponse[]): ContestResponse[] {
+    const indexedGroups = Object.fromEntries(Object.entries(this.allGroupsIds).map(([index, val]) => [val, +index]));
+    const indexedContests = Object.fromEntries(Object.entries(this.allContests).map(([index, val]) => [val, +index]));
+
+    return [...contests].sort((c1, c2) =>
+      indexedGroups[c1.groupId] === indexedGroups[c2.groupId]
+        ? indexedContests[c1.id] - indexedContests[c2.id]
+        : indexedGroups[c1.groupId] - indexedGroups[c2.groupId],
+    );
   }
 }


### PR DESCRIPTION
Given a config with specific contests/groups order we might get them unordered
Example config: https://api.jsonbin.io/b/621f890d7caf5d67835db39d

- Current response:
```json
{
  "trainees": [...],
  "sheets": [
  {
    "id": 348729,
      "groupId": "n3stiythxi",
      "name": "Week #1",
      "problems": [...]
  },
  {
    "id": 348730,
    "groupId": "n3stiythxi",
    "name": "Week #2",
    "problems": [...]
  },
  {
    "id": 348732,
    "groupId": "n3stiythxi",
    "name": "Week #4",
    "problems": [...]
  },
  {
    "id": 348733,
    "groupId": "n3stiythxi",
    "name": "Week #6",
    "problems": [...]
  },
  ...
}
```

- Expected response:
```json
{
  "trainees": [...],
  "sheets": [
  {
    "id": 348729,
      "groupId": "n3stiythxi",
      "name": "Week #1",
      "problems": [...]
  },
  {
    "id": 348730,
    "groupId": "n3stiythxi",
    "name": "Week #2",
    "problems": [...]
  },
  {
    "id": 360152,
    "groupId": "n3stiythxi",
    "name": "Week #3",
    "problems": [...]
  },
  {
    "id": 348732,
    "groupId": "n3stiythxi",
    "name": "Week #4",
    "problems": [...]
  },
  ...
}
```
