### PR TITLE
 adapt fetching configUrl to JSONBin.io V3 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,29 +24,36 @@ npm run dev
 required query variable:
 
 - **configs**: a URL that returns JSON in the following format.  
-e.g. <https://api.jsonbin.io/b/6175e8fc9548541c29c80745>
+e.g. <https://api.jsonbin.io/v3/b/6175e8fc9548541c29c80745>
 
 ```json
 {
-  "groups": [
-    {
-      "id": "MWSDmqGsZm",
-      "contests": [
-        "219158",
-        219432
-      ]
-    }
-  ],
-  "trainees": [
-    {
-      "name": "Amr Salama",
-      "handle": "AmrSalama"
-    },
-    {
-      "name": "Kerollos Magdy",
-      "handle": "Kerolloz"
-    }
-  ]
+  "record": {
+    "groups": [
+      {
+        "id": "MWSDmqGsZm",
+        "contests": [
+          "219158",
+          219432
+        ]
+      }
+    ],
+    "trainees": [
+      {
+        "name": "Amr Salama",
+        "handle": "AmrSalama"
+      },
+      {
+        "name": "Kerollos Magdy",
+        "handle": "Kerolloz"
+      }
+    ]
+  },
+  "metadata": {
+    "id": "6175e8fc9548541c29c80745",
+    "private": false,
+    "createdAt": "2021-10-24T23:15:08.155Z"
+  }
 }
 ```
 
@@ -54,6 +61,6 @@ e.g. <https://api.jsonbin.io/b/6175e8fc9548541c29c80745>
 
 Example:
 
-<https://api.boardy.cf/?configs=https://api.jsonbin.io/b/6175e8fc9548541c29c80745>
+<https://api.boardy.cf/?configs=https://api.jsonbin.io/v3/b/6175e8fc9548541c29c80745>
 
 Open the URL to see the response.

--- a/src/controllers/getData.ts
+++ b/src/controllers/getData.ts
@@ -27,7 +27,9 @@ export default endpoint({ query: { configs: urlValidator } }, async (req) => {
   console.time('fetch json config');
   let configs;
   try {
-    configs = await RequestCache.getJSON<ConfigsType>(configsUrl);
+    type JsonBinV3Response<T> = { record: T };
+    const response = await RequestCache.getJSON<JsonBinV3Response<ConfigsType>>(configsUrl);
+    configs = response.record;
   } catch (error) {
     console.timeEnd('fetch json config');
     if (error instanceof RequestCache.HttpError) {


### PR DESCRIPTION
API v2 is now deprecated. We have to upgrade to API v3.
 https://jsonbin.io/api-reference

API V3 returns a different JSON response. It doesn't directly respond with the saved JSON. It returns the JSON wrapped in a field named `record` and adds a `metadata` field. 

--- 
https://api.jsonbin.io/b/6175e8fc9548541c29c80745
The previous URL used to return the following response 
```json
{
  "groups": [
    {
      "id": "MWSDmqGsZm",
      "contests": [
        "219158",
        219432
      ]
    }
  ],
  "trainees": [
    {
      "name": "Amr Salama",
      "handle": "AmrSalama"
    },
    {
      "name": "Kerollos Magdy",
      "handle": "Kerolloz"
    }
  ]
}
```
Now we have to use the aforementioned URL like this https://api.jsonbin.io/v3/b/6175e8fc9548541c29c80745 to get the following response
```json
{
  "record": {
    "groups": [
      {
        "id": "MWSDmqGsZm",
        "contests": [
          "219158",
          219432
        ]
      }
    ],
    "trainees": [
      {
        "name": "Amr Salama",
        "handle": "AmrSalama"
      },
      {
        "name": "Kerollos Magdy",
        "handle": "Kerolloz"
      }
    ]
  },
  "metadata": {
    "id": "6175e8fc9548541c29c80745",
    "private": false,
    "createdAt": "2021-10-24T23:15:08.155Z"
  }
}
```